### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Costas K"]
 description = "A minimal AWS sigv4 verification library"
 readme = "README.md"
-homepage = "https://github.com/ClothoProxy/Clotho"
+repository = "https://github.com/ClothoProxy/Clotho"
 license = "MIT"
 keywords = ["AWS", "proxy", "security"]
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field).